### PR TITLE
Allow dynamic switching of Facing

### DIFF
--- a/Camera.uno
+++ b/Camera.uno
@@ -32,7 +32,15 @@ public extern(iOS) class Camera
 {
   ObjC.ID _handle;
   public CameraFacing _facing = CameraFacing.Default;
-  public CameraFacing Facing { get { return _facing; } set { _facing = value; } }
+  public CameraFacing Facing {
+    get {
+      return _facing;
+    }
+    set {
+      _facing = value;
+      RefreshCamera();
+    }
+  }
 
   public void Start() {
     debug_log("Start");

--- a/Camera.uno
+++ b/Camera.uno
@@ -45,7 +45,9 @@ public extern(iOS) class Camera
     CameraImpl.stop(_handle);
   }
 
-  public void RefreshCamera() {}
+  public void RefreshCamera() {
+    CameraImpl.refresh(_handle, (int)Facing);
+  }
 
   public Promise<PictureResult> TakePicture() {
     var p = new Promise<PictureResult>();
@@ -116,6 +118,9 @@ internal class CameraImpl
 
   [TargetSpecificImplementation]
   public static extern void start(ObjC.ID camera, int devicetype);
+
+  [TargetSpecificImplementation]
+  public static extern void refresh(ObjC.ID camera, int devicetype);
 
   [TargetSpecificImplementation]
   public static extern void stop(ObjC.ID camera);

--- a/Camera.uxl
+++ b/Camera.uxl
@@ -10,7 +10,7 @@
     	<Require Entity="Uno.Action" />
        	<Require Entity="ObjC.Object" />
        	<Require Source.Import="FuseCameraImpl.h" />
-       	<Require Source.Include="uObjC.h" />
+       	<!-- Require Source.Include="uObjC.h" /-->
        	<Method Signature="allocateCamera():ObjC.ID">
        		<Body>
        			FuseCameraImpl *fci = [[FuseCameraImpl alloc] init];

--- a/Camera.uxl
+++ b/Camera.uxl
@@ -28,6 +28,12 @@
        			[fci startCam: $1];
        		</Body>
        	</Method>
+       	<Method Signature="refresh(ObjC.ID,int)">
+       		<Body>
+       			FuseCameraImpl *fci = (FuseCameraImpl *)$0;
+       			[fci refresh: $1];
+       		</Body>
+       	</Method>
        	<Method Signature="stop(ObjC.ID)">
        		<Body>
        			FuseCameraImpl *fci = (FuseCameraImpl *)$0;

--- a/FuseCameraImpl.mm
+++ b/FuseCameraImpl.mm
@@ -62,6 +62,13 @@
     [self setupAVCapture:device];
 }
 
+- (void)refresh:(int)device
+{
+    if (_session) {
+        [self configureCaptureSession:_session withDeviceType:device];
+    }
+}
+
 - (void)stopCam
 {    
     [_session stopRunning];


### PR DESCRIPTION
This pull request allows the `Facing` to be responsive to changes. I've done this by extracting the logic from `captureOutput` that configures the capture session and pulling it into a new function `configureCaptureSession` that is called when the Facing is changed. I also repurposed the `RefreshCamera` function (which didn't have an implementation before) to trigger that re-configuration.  

Separately, commit `be6da83` comments out a Require for `uObjC.h` which was causing an XCode error, but I can split that out if that's not appropriate.  
